### PR TITLE
feat(cup): add initial cup cli formula (v0.1.2)

### DIFF
--- a/Formula/cup.rb
+++ b/Formula/cup.rb
@@ -1,9 +1,9 @@
 class Cup < Formula
-  desc "A CLI for communicating with cupd"
+  desc "CLI for communicating with cupd"
   homepage "https://cup.flipt.io"
-  license "apache-2.0"
   url "https://github.com/flipt-io/cup/archive/refs/tags/v0.1.2.tar.gz"
   sha256 "8a92c7d849bbbba13f1e3c47918cb2cd13bc9b147433fa69e6dc968b99e3585a"
+  license "Apache-2.0"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
This adds an initial pass at adding a homebrew tap for the `cup` CLI.

I went through the hoops setting up builds on the Cup repo.
However, I eventually just settled on this approach (build from source).
Given `cup` being currently so simple, a lot of headaches get removed by doing it this way.
No code signing or notarizing necessary.

There is currently no automation keeping this up to date. I want to look at that next.
I have a suspicion this might be something `cup` itself could help with.